### PR TITLE
[BE/feature] 매수 매도 기능 DB 동기화

### DIFF
--- a/apps/backend/src/database/database.service.ts
+++ b/apps/backend/src/database/database.service.ts
@@ -5,6 +5,7 @@ import { Client, QueryResult } from 'pg';
 @Injectable()
 export class DatabaseService implements OnModuleInit {
   private client: Client;
+
   constructor(private configService: ConfigService) {}
 
   onModuleInit() {
@@ -21,7 +22,8 @@ export class DatabaseService implements OnModuleInit {
       .catch((error: Error) => console.error('Failed to connect to PostgreSQL database', error));
   }
 
-  async query(query: string, params: string[] = []): Promise<QueryResult> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async query(query: string, params: any[] = []): Promise<QueryResult> {
     return this.client.query(query, params);
   }
 

--- a/apps/backend/src/order/dto/baseOrder.dto.ts
+++ b/apps/backend/src/order/dto/baseOrder.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { OrderType, TradingType } from '../enums/orderType';
+
+export class BaseOrderDto {
+  @ApiProperty({ description: '상품 ID', example: 1 })
+  cropId: number;
+
+  @ApiProperty({ description: '회원 ID', example: 123 })
+  memberId: number;
+
+  @ApiProperty({ description: '주문 유형', example: 'buy' })
+  orderType: OrderType;
+
+  @ApiProperty({ description: '거래 유형', example: 'limit' })
+  tradingType: TradingType;
+}

--- a/apps/backend/src/order/dto/limitOrder.dto.ts
+++ b/apps/backend/src/order/dto/limitOrder.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { BaseOrderDto } from './baseOrder.dto';
+
+export class LimitOrderDto extends BaseOrderDto {
+  @ApiProperty({ description: '주문 수량', example: 100 })
+  quantity: number;
+
+  @ApiProperty({ description: '주문 가격', example: 50 })
+  price: number;
+}

--- a/apps/backend/src/order/dto/order.dto.ts
+++ b/apps/backend/src/order/dto/order.dto.ts
@@ -1,13 +1,26 @@
-export class OrderDto {
-  orderId: number;
-  cropId: number;
+import { ApiProperty } from '@nestjs/swagger';
+import { BaseOrderDto } from './baseOrder.dto';
+import { OrderStatus } from '../enums/orderType';
+
+export class OrderDto extends BaseOrderDto {
+  @ApiProperty({ description: '회원 번호', example: 15 })
   memberId: number;
-  orderType: 'buy' | 'sell';
-  time: Date;
-  quantity: number;
+
+  @ApiProperty({ description: '주문 상태', example: 'pending' })
+  status: OrderStatus;
+
+  @ApiProperty({ description: '주문 가격', example: 1500 })
   price: number;
-  status: 'pending' | 'partially_filled' | 'completed' | 'canceled';
+
+  @ApiProperty({ description: '주문 시간', example: new Date() })
+  time: Date;
+
+  @ApiProperty({ description: '주문 수량', example: 100 })
+  quantity: number;
+
+  @ApiProperty({ description: '체결된 수량', example: 50 })
   filledQuantity: number;
-  tradingType: 'limit' | 'market';
+
+  @ApiProperty({ description: '미체결 수량', example: 50 })
   unfilledQuantity: number;
 }

--- a/apps/backend/src/order/dto/orderBook.dto.ts
+++ b/apps/backend/src/order/dto/orderBook.dto.ts
@@ -1,8 +1,22 @@
-export interface OrderBookDto {
+import { ApiProperty } from '@nestjs/swagger';
+import { OrderType } from '../enums/orderType';
+
+export class OrderBookDto {
+  @ApiProperty({ description: '주문 ID', example: 1 })
   orderId: number;
+
+  @ApiProperty({ description: '상품 ID', example: 1 })
   cropId: number;
-  orderType: 'buy' | 'sell';
+
+  @ApiProperty({ description: '주문 유형', example: 'buy' })
+  orderType: OrderType;
+
+  @ApiProperty({ description: '가격', example: 50 })
   price: number;
+
+  @ApiProperty({ description: '미체결 수량', example: 100 })
   unfilledQuantity: number;
-  timestamp: number;
+
+  @ApiProperty({ description: '주문 시간', example: new Date() })
+  time: Date;
 }

--- a/apps/backend/src/order/enums/orderType.ts
+++ b/apps/backend/src/order/enums/orderType.ts
@@ -1,0 +1,16 @@
+export enum OrderType {
+  BUY = 'buy',
+  SELL = 'sell'
+}
+
+export enum TradingType {
+  LIMIT = 'limit',
+  MARKET = 'market'
+}
+
+export enum OrderStatus {
+  PENDING = 'pending',
+  PARTIALLY_FILLED = 'partially_filled',
+  COMPLETED = 'completed',
+  CANCELED = 'canceled'
+}

--- a/apps/backend/src/order/matching.service.ts
+++ b/apps/backend/src/order/matching.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { OrderBookService } from './orderBook.service';
+import { OrderType } from './enums/orderType';
 
 @Injectable()
 export class MatchingService {
@@ -24,8 +25,18 @@ export class MatchingService {
 
       //TODO DB 트랜잭션 업데이트,체결 이벤트 발생
 
-      await this.orderBookService.updateOrder(cropId, 'buy', buyOrder.orderId, matchedQuantity);
-      await this.orderBookService.updateOrder(cropId, 'sell', sellOrder.orderId, matchedQuantity);
+      await this.orderBookService.updateOrder(
+        cropId,
+        OrderType.BUY,
+        buyOrder.orderId,
+        matchedQuantity
+      );
+      await this.orderBookService.updateOrder(
+        cropId,
+        OrderType.SELL,
+        sellOrder.orderId,
+        matchedQuantity
+      );
 
       if (sellOrder.unfilledQuantity <= matchedQuantity) {
         sellIndex++;

--- a/apps/backend/src/order/order.controller.ts
+++ b/apps/backend/src/order/order.controller.ts
@@ -1,8 +1,10 @@
 import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { OrderService } from './order.service';
 import { OrderBookService } from './orderBook.service';
-import { OrderDto } from './dto/order.dto';
 import { OrderBookDto } from './dto/orderBook.dto';
+import DtoTransformer from './utils/dtoTransformer';
+import { LimitOrderDto } from './dto/limitOrder.dto';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 @Controller('api/order')
 export class OrderController {
@@ -12,28 +14,34 @@ export class OrderController {
   ) {}
 
   @Post('buy')
-  async createBuyOrder(@Body() orderDto: OrderDto): Promise<string> {
-    // TODO: 주문 데이터를 데이터베이스에 저장
-    await this.orderService.placeOrder(orderDto);
+  @ApiOperation({ summary: '구매 주문 생성' })
+  @ApiResponse({ status: 200, description: '구매 주문이 성공적으로 생성되었습니다.' })
+  async createBuyOrder(@Body() limitOrderDto: LimitOrderDto): Promise<string> {
+    const orderDto = DtoTransformer.toOrderDto(limitOrderDto);
+    const orderId = await this.orderService.saveOrder(orderDto);
+
+    await this.orderService.saveOrderToOrderBook(orderDto, orderId);
     return '구매 주문이 성공적으로 생성되었습니다.';
   }
 
   @Post('sell')
-  async createSellOrder(@Body() orderDto: OrderDto): Promise<string> {
-    // TODO: 주문 데이터를 데이터베이스에 저장
-    await this.orderService.placeOrder(orderDto);
+  @ApiOperation({ summary: '판매 주문 생성' })
+  @ApiResponse({ status: 200, description: '판매 주문이 성공적으로 생성되었습니다.' })
+  async createSellOrder(@Body() limitOrderDto: LimitOrderDto): Promise<string> {
+    const orderDto = DtoTransformer.toOrderDto(limitOrderDto);
+    const orderId = await this.orderService.saveOrder(orderDto);
+
+    await this.orderService.saveOrderToOrderBook(orderDto, orderId);
     return '판매 주문이 성공적으로 생성되었습니다.';
   }
 
   @Get('buy/:cropId')
   async getBuyOrders(@Param('cropId') cropId: number): Promise<OrderBookDto[]> {
-    // TODO: 필요 시 데이터베이스에서 데이터를 가져옴
     return await this.orderBookService.getBuyOrders(cropId);
   }
 
   @Get('sell/:cropId')
   async getSellOrders(@Param('cropId') cropId: number): Promise<OrderBookDto[]> {
-    // TODO: 필요 시 데이터베이스에서 데이터를 가져옴
     return await this.orderBookService.getSellOrders(cropId);
   }
 
@@ -42,7 +50,6 @@ export class OrderController {
     @Body()
     { cropId, orderId, orderType }: { cropId: number; orderId: number; orderType: 'buy' | 'sell' }
   ): Promise<string> {
-    // TODO: 데이터베이스에서 주문 상태를 "취소됨"으로 업데이트
     await this.orderBookService.removeOrder(cropId, orderId, orderType);
     return '주문이 성공적으로 취소되었습니다.';
   }

--- a/apps/backend/src/order/order.module.ts
+++ b/apps/backend/src/order/order.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { OrderService } from './order.service';
 import { OrderController } from './order.controller';
 import { OrderBookService } from './orderBook.service';
+import { OrderRepository } from './order.repository';
+import { DatabaseModule } from '../database/database.module';
 
 @Module({
-  providers: [OrderService, OrderBookService],
-  controllers: [OrderController]
+  providers: [OrderService, OrderBookService, OrderRepository],
+  controllers: [OrderController],
+  imports: [DatabaseModule]
 })
 export class OrderModule {}

--- a/apps/backend/src/order/order.repository.ts
+++ b/apps/backend/src/order/order.repository.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import { OrderDto } from './dto/order.dto';
+import { OrderStatus } from './enums/orderType';
+
+@Injectable()
+export class OrderRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async saveOrder(order: OrderDto): Promise<number> {
+    const query = `
+            INSERT INTO orders (crop_id,
+                                member_id,
+                                order_type,
+                                trading_type,
+                                quantity,
+                                price,
+                                status,
+                                filled_quantity,
+                                unfilled_quantity,
+                                time)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING order_id
+        `;
+
+    const values = [
+      order.cropId,
+      order.memberId,
+      order.orderType,
+      order.tradingType,
+      order.quantity,
+      order.price,
+      order.status || OrderStatus.PENDING, // 기본값 설정
+      order.filledQuantity || 0,
+      order.unfilledQuantity || order.quantity,
+      order.time || new Date()
+    ];
+
+    const result = await this.databaseService.query(query, values);
+    return result.rows[0].order_id;
+  }
+}

--- a/apps/backend/src/order/order.service.ts
+++ b/apps/backend/src/order/order.service.ts
@@ -1,20 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { OrderBookService } from './orderBook.service';
+import { OrderRepository } from './order.repository';
 import { OrderDto } from './dto/order.dto';
+import { LimitOrderDto } from './dto/limitOrder.dto';
+import DtoTransformer from './utils/dtoTransformer';
 
 @Injectable()
 export class OrderService {
-  constructor(private readonly orderBookService: OrderBookService) {}
+  constructor(
+    private readonly orderBookService: OrderBookService,
+    private readonly orderRepository: OrderRepository
+  ) {}
 
-  async placeOrder(order: OrderDto): Promise<void> {
-    const orderBookDto = {
-      orderId: order.orderId,
-      cropId: order.cropId,
-      orderType: order.orderType,
-      price: order.price,
-      unfilledQuantity: order.quantity,
-      timestamp: Date.now()
-    };
+  async saveOrder(createOrderDto: LimitOrderDto): Promise<number> {
+    const orderDto: OrderDto = DtoTransformer.toOrderDto(createOrderDto);
+    const orderId = await this.orderRepository.saveOrder(orderDto);
+
+    await this.saveOrderToOrderBook(orderDto, orderId);
+
+    return orderId;
+  }
+
+  async saveOrderToOrderBook(order: OrderDto, orderId: number): Promise<void> {
+    const orderBookDto = DtoTransformer.toOrderBookDto(order, orderId);
     await this.orderBookService.addOrder(orderBookDto);
   }
 }

--- a/apps/backend/src/order/orderBook.service.ts
+++ b/apps/backend/src/order/orderBook.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { RedisClientType } from 'redis';
 import { OrderBookDto } from './dto/orderBook.dto';
+import { OrderType } from './enums/orderType';
 
 @Injectable()
 export class OrderBookService {
@@ -36,12 +37,14 @@ export class OrderBookService {
 
   async updateOrder(
     cropId: number,
-    orderType: 'buy' | 'sell',
+    orderType: OrderType,
     orderId: number,
     filledQuantity: number
   ): Promise<void> {
     const orders =
-      orderType === 'buy' ? await this.getBuyOrders(cropId) : await this.getSellOrders(cropId);
+      orderType === OrderType.BUY
+        ? await this.getBuyOrders(cropId)
+        : await this.getSellOrders(cropId);
     const targetOrder = orders.find(order => order.orderId === orderId);
 
     if (!targetOrder) {
@@ -57,7 +60,8 @@ export class OrderBookService {
   }
 
   private serializeOrder(order: OrderBookDto): string {
-    return JSON.stringify(order);
+    const time = order.time.toISOString();
+    return JSON.stringify({ ...order, time });
   }
 
   private deserializeOrder(orderData: string): OrderBookDto {

--- a/apps/backend/src/order/utils/dtoTransformer.ts
+++ b/apps/backend/src/order/utils/dtoTransformer.ts
@@ -1,0 +1,32 @@
+import { OrderDto } from '../dto/order.dto';
+import { OrderBookDto } from '../dto/orderBook.dto';
+import { LimitOrderDto } from '../dto/limitOrder.dto';
+import { OrderStatus } from '../enums/orderType';
+
+export default class DtoTransformer {
+  static toOrderBookDto(order: OrderDto, orderId: number): OrderBookDto {
+    return {
+      orderId,
+      cropId: order.cropId,
+      orderType: order.orderType,
+      price: order.price,
+      unfilledQuantity: order.quantity,
+      time: order.time
+    };
+  }
+
+  static toOrderDto(limitOrderDto: LimitOrderDto): OrderDto {
+    return {
+      cropId: limitOrderDto.cropId,
+      memberId: limitOrderDto.memberId,
+      orderType: limitOrderDto.orderType,
+      tradingType: limitOrderDto.tradingType,
+      time: new Date(), // 현재 시간으로 설정
+      quantity: limitOrderDto.quantity,
+      price: limitOrderDto.price,
+      status: OrderStatus.PENDING, // 초기 상태를 기본값으로 설정
+      filledQuantity: 0, // 초기 체결 수량
+      unfilledQuantity: limitOrderDto.quantity // 전체 수량을 미체결로 설정
+    };
+  }
+}


### PR DESCRIPTION
## 주요 작업

- [x] 기존 Redis에만 저장했던 오더정보 DB 동기화 및 저장
- [x] enum 으로 주문 타입 분리
  
## 트러블 슈팅

- 오더북, 리밋오더, 마켓오더 등 오더 종류가 많아 각 오더를 dto를 사용해서  나누는 방식이 좋은 방식인지 어려움.
- 에러처리, 동시성 문제 생각하지 않고 우선 동작하는 기능을 만들기 위해 개발 중
- 깃 문제로 커밋 한개에 모든 파일이 올라갔습니다. 다음 PR에서는 기능 단위 커밋으로 진행하겠습니다.