### PR TITLE
[FE/feat] 알람 기능 추가 및 리팩토링

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "apexcharts": "^4.0.0",
     "axios": "^1.7.7",
+    "event-source-polyfill": "^1.0.31",
     "framer-motion": "^11.11.15",
     "frontend": "file:",
     "react": "^18.3.1",

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Footer from '@/components/Footer';
 import PrivateRoute from '@/components/ProtectRoute';
 import OauthLogin from '@/components/OauthLogin';
 import { UserProvider } from '@/components/UserContext';
+import { AlertDialog } from './components/AlertContext';
 
 interface LayoutProps {
   path: string;
@@ -54,13 +55,15 @@ const router = createBrowserRouter(routes);
 
 function App() {
   return (
-    <div className="bg-bg-color min-h-screen">
-      <UserProvider>
-        <AnimatePresence>
-          <RouterProvider router={router} />
-        </AnimatePresence>
-      </UserProvider>
-    </div>
+    <AlertDialog>
+      <div className="bg-bg-color min-h-screen">
+        <UserProvider>
+          <AnimatePresence>
+            <RouterProvider router={router} />
+          </AnimatePresence>
+        </UserProvider>
+      </div>
+    </AlertDialog>
   );
 }
 

--- a/apps/frontend/src/components/AlarmModal.tsx
+++ b/apps/frontend/src/components/AlarmModal.tsx
@@ -1,14 +1,24 @@
+import React from 'react';
 import CloseIcon from './CloseIcon';
 import { Alarm } from '@/types/Index';
 
 interface AlarmModalProps {
   alarms: Alarm[];
+  setIsNewAlarm: (isNewAlarm: boolean) => void;
+  error: string | null;
   isOpen: boolean;
   closeModal: () => void;
   clearAllAlarms: () => void;
 }
 
-const AlarmModal: React.FC<AlarmModalProps> = ({ alarms, isOpen, closeModal, clearAllAlarms }) => {
+const AlarmModal: React.FC<AlarmModalProps> = ({
+  alarms,
+  setIsNewAlarm,
+  error,
+  isOpen,
+  closeModal,
+  clearAllAlarms
+}) => {
   if (!isOpen) return;
 
   const timeAgo = (date: string): string => {
@@ -36,39 +46,47 @@ const AlarmModal: React.FC<AlarmModalProps> = ({ alarms, isOpen, closeModal, cle
   };
 
   return (
-    <div className="fixed top-12 right-24 mt-12 mr-8 select-none">
+    <div
+      className="fixed w-[312px] top-24 right-32 select-none"
+      onClick={() => setIsNewAlarm(false)}
+    >
       <div className="flex flex-col items-center bg-light-beige border-4 border-light-pink rounded-2xl p-4 shadow-lg w-76">
         <div className="flex justify-end w-full">
           <CloseIcon onClick={closeModal} />
         </div>
-        {alarms.length > 0 && (
+        {error ? (
+          <p className="text-center text-xs text-brown-medium mt-4 mb-2">{error}</p>
+        ) : (
           <>
-            <div className="max-h-[260px] overflow-y-auto mt-4">
-              {alarms.map(alarm => (
-                <div
-                  key={alarm.mailId}
-                  className="flex items-center w-full border-b border-light-pink py-3 px-2"
-                >
-                  <img src="/coin.png" alt="coin" className="w-10 h-10 mr-4" />
-                  <div className="flex flex-col text-brown-medium text-center text-xs gap-1">
-                    <p className="flex font-semibold">{alarm.content}</p>
-                    <p className="flex justify-end font-normal">{timeAgo(alarm.createAt)}</p>
-                  </div>
+            {alarms.length > 0 ? (
+              <>
+                <div className="max-h-[260px] overflow-y-auto mt-6">
+                  {alarms.map((alarm, index) => (
+                    <div
+                      key={`${alarm.mailId}-${index}`}
+                      className="flex items-center w-full border-b border-light-pink py-3 px-2"
+                    >
+                      <img src="/coin.png" alt="coin" className="w-10 h-10 mr-4" />
+                      <div className="flex flex-col w-full text-brown-medium text-center text-xs gap-1">
+                        <p className="flex font-semibold">{alarm.content}</p>
+                        <p className="flex justify-end font-normal">{timeAgo(alarm.createdAt)}</p>
+                      </div>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-            <button
-              onClick={clearAllAlarms}
-              className="flex justify-end w-full text-xs mt-4 text-red-alert px-4 py-2"
-            >
-              알림 전체 삭제
-            </button>
+                <button
+                  onClick={clearAllAlarms}
+                  className="flex justify-end w-full text-xs mt-4 text-red-alert px-4 py-2"
+                >
+                  알림 전체 삭제
+                </button>
+              </>
+            ) : (
+              <p className="text-center text-xs text-brown-medium py-4 px-3">
+                알림 내역이 존재하지 않습니다.
+              </p>
+            )}
           </>
-        )}
-        {alarms.length === 0 && (
-          <p className="text-center text-xs text-brown-medium mt-4 mb-2">
-            알림 내역이 존재하지 않습니다.
-          </p>
         )}
       </div>
     </div>

--- a/apps/frontend/src/components/AlarmModal.tsx
+++ b/apps/frontend/src/components/AlarmModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import CloseIcon from './CloseIcon';
 import { Alarm } from '@/types/Index';
 

--- a/apps/frontend/src/components/Alert.tsx
+++ b/apps/frontend/src/components/Alert.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+
+interface AlertProps {
+  message: string;
+  onClickOK: () => void;
+}
+
+const Alert: React.FC<AlertProps> = ({ message, onClickOK }) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        onClickOK();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClickOK]);
+
+  return (
+    <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-50 z-50">
+      <div className="flex flex-col items-center text-center bg-light-yellow bg-opacity-90 p-8 rounded-lg shadow-lg max-w-[400px] w-full">
+        <p className="mb-6 font-bold text-lg">{message}</p>
+        <div className="flex flex-row justify-center gap-4">
+          <button
+            onClick={onClickOK}
+            className="p-2 mt-2 bg-brown-dark text-light-gray rounded-lg min-w-[160px] min-h-[35px] text-sm"
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Alert;

--- a/apps/frontend/src/components/Alert.tsx
+++ b/apps/frontend/src/components/Alert.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 interface AlertProps {
   message: string;

--- a/apps/frontend/src/components/AlertContext.tsx
+++ b/apps/frontend/src/components/AlertContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react';
+import { createContext, useState } from 'react';
 import Alert from '@/components/Alert';
 
 type Type = {

--- a/apps/frontend/src/components/AlertContext.tsx
+++ b/apps/frontend/src/components/AlertContext.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useState } from 'react';
+import Alert from '@/components/Alert';
+
+type Type = {
+  alert: (message?: string) => Promise<boolean>;
+};
+
+export const AlertContext = createContext<Type>({
+  alert: () => new Promise((_, reject) => reject())
+});
+
+type AlertState = {
+  message: string;
+  onClickOK: () => void;
+  onClickCancel: () => void;
+};
+
+export const AlertDialog = ({ children }: { children: React.ReactNode }) => {
+  const [state, setState] = useState<AlertState>();
+
+  const alert = (message?: string): Promise<boolean> => {
+    return new Promise(resolve => {
+      setState({
+        message: message ?? '',
+        onClickOK: () => {
+          setState(undefined);
+          resolve(true);
+        },
+        onClickCancel: () => {
+          setState(undefined);
+          resolve(false);
+        }
+      });
+    });
+  };
+
+  return (
+    <AlertContext.Provider value={{ alert }}>
+      {children}
+      {state && <Alert message={state.message} onClickOK={state.onClickOK} />}
+    </AlertContext.Provider>
+  );
+};

--- a/apps/frontend/src/components/AskingPrice.tsx
+++ b/apps/frontend/src/components/AskingPrice.tsx
@@ -42,7 +42,7 @@ const AskingPrice: React.FC<AskingPriceProps> = ({ crop }) => {
         <div className="text-center">가격</div>
         <div className="text-center">수량</div>
       </div>
-      <div className="md:max-h-16 lg:max-h-26 xl:max-h-28 overflow-y-auto">
+      <div className="md:h-24 lg:h-26 xl:h-28 overflow-y-auto">
         {cropPrices[crop].map(([type, price, qty], idx) => (
           <div key={idx} className="grid grid-cols-[1fr_1fr_1fr] gap-1 py-1 px-1 items-center">
             <div className="text-center">{type}</div>

--- a/apps/frontend/src/components/BarModal.tsx
+++ b/apps/frontend/src/components/BarModal.tsx
@@ -1,5 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { logout } from '@/services/AuthApi';
+import { AlertContext } from '@/components/AlertContext';
+import { useContext } from 'react';
 
 interface BarProps {
   isOpen: boolean;
@@ -8,14 +10,15 @@ interface BarProps {
 
 const BarModal: React.FC<BarProps> = ({ isOpen, closeModal }) => {
   const navigate = useNavigate();
+  const { alert } = useContext(AlertContext);
 
   const handleLogout = async () => {
-    const result = await logout();
+    const response = await logout();
 
-    if (result.success) {
+    if (response.success) {
       navigate('/');
     } else {
-      alert(result.message);
+      await alert(response.message || '로그아웃 중 오류가 발생했습니다. 다시 시도해주세요.');
     }
     closeModal();
   };

--- a/apps/frontend/src/components/EditNicknameModal.tsx
+++ b/apps/frontend/src/components/EditNicknameModal.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import CloseIcon from './CloseIcon';
 import { updateNickname } from '@/services/AuthApi';
 import { useUser } from './UserContext';
+import { AlertContext } from '@/components/AlertContext';
 
 interface EditNicknameModalProps {
   isOpen: boolean;
@@ -11,7 +12,7 @@ interface EditNicknameModalProps {
 const EditNicknameModal: React.FC<EditNicknameModalProps> = ({ isOpen, modalOpen }) => {
   const { nickname, setNickname } = useUser();
   const [tmpNickname, setTmpNickname] = useState<string>(nickname);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { alert } = useContext(AlertContext);
 
   const handleNicknameChange = async () => {
     if (tmpNickname === nickname) {
@@ -22,23 +23,18 @@ const EditNicknameModal: React.FC<EditNicknameModalProps> = ({ isOpen, modalOpen
     try {
       const response = await updateNickname({ nickname: tmpNickname });
       if (response.success) {
-        setErrorMessage(null);
         setNickname(tmpNickname);
-
         modalOpen();
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        setErrorMessage(error.message || '서버와의 연결에 실패했습니다.');
       } else {
-        setErrorMessage('서버와의 연결에 실패했습니다.');
+        await alert(response.message || '닉네임 변경 중 오류가 발생했습니다. 다시 시도해주세요.');
       }
+    } catch {
+      await alert('닉네임 변경 중 오류가 발생했습니다. 다시 시도해주세요.');
     }
   };
 
   const handleCancelEdit = () => {
     setTmpNickname(nickname);
-    setErrorMessage(null);
     modalOpen();
   };
 
@@ -58,7 +54,6 @@ const EditNicknameModal: React.FC<EditNicknameModalProps> = ({ isOpen, modalOpen
               className="rounded px-4 py-1 text-base text-center min-w-[200px] "
               value={tmpNickname}
             />
-            {errorMessage && <div className="text-sm text-red-600">{errorMessage}</div>}
           </div>
           <div className="flex flex-row justify-end gap-4 mt-8">
             <button

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -1,64 +1,114 @@
 import { Link } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useEffect, useRef, useContext } from 'react';
+import { EventSourcePolyfill } from 'event-source-polyfill';
 import AlarmModal from '@/components/AlarmModal';
 import BarModal from '@/components/BarModal';
 import { Alarm } from '@/types/Index';
 import { useUser } from '@/components/UserContext';
+import { getAlarm, clearAlarm } from '@/services/MailApi';
+import { AlertContext } from '@/components/AlertContext';
 
 const Header: React.FC = () => {
-  const [alarms, setAlarms] = useState<Alarm[]>([
-    {
-      mailId: 1,
-      content: '당근을 500원에 20개를 매수하셨습니다.',
-      createAt: '2024-11-20T11:16:00.000Z',
-      readStatus: false
-    },
-    {
-      mailId: 2,
-      content: '당근을 500원에 20개를 매수하셨습니다.',
-      createAt: '2024-11-20T11:00:00.000Z',
-      readStatus: false
-    },
-    {
-      mailId: 3,
-      content: '당근을 500원에 20개를 매수하셨습니다.',
-      createAt: '2024-11-20T10:00:00.000Z',
-      readStatus: false
-    },
-    {
-      mailId: 4,
-      content: '당근을 500원에 20개를 매수하셨습니다.',
-      createAt: '2024-11-19T15:00:00.000Z',
-      readStatus: false
-    },
-    {
-      mailId: 5,
-      content: '당근을 500원에 20개를 매수하셨습니다.',
-      createAt: '2024-10-11T15:00:00.000Z',
-      readStatus: false
-    },
-    {
-      mailId: 6,
-      content: '당근을 500원에 20개를 매수하셨습니다.',
-      createAt: '2023-11-11T15:00:00.000Z',
-      readStatus: false
-    }
-  ]);
+  const [alarms, setAlarms] = useState<Alarm[]>([]);
+  const [error, setError] = useState<string | null>(null);
   const [isAlarmOpen, setIsAlarmOpen] = useState<boolean>(false);
   const [isBarOpen, setIsBarOpen] = useState<boolean>(false);
+  const [isNewAlarm, setIsNewAlarm] = useState<boolean>(false);
   const { nickname, totalAssets } = useUser();
+  const { alert } = useContext(AlertContext);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectDelay = 3000;
+
+  const isJson = (data: string) => {
+    try {
+      JSON.parse(data);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const fetchAlarm = async () => {
+    try {
+      const response = await getAlarm();
+      if (response.success) {
+        setAlarms(response.alarm);
+        setError(null);
+      } else {
+        setError(response.message || '데이터 로딩 중 오류가 발생했습니다.');
+      }
+    } catch {
+      setError('서버와의 연결에 실패했습니다.');
+    }
+  };
+
+  const createEventSource = () => {
+    const EventSource = EventSourcePolyfill || window.EventSource;
+
+    const eventSource = new EventSource('http://localhost:8080/api/mail/check', {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('accessToken')}`
+      }
+    });
+
+    eventSource.onmessage = (event: MessageEvent) => {
+      if (isJson(event.data)) {
+        const parsedData = JSON.parse(event.data);
+
+        if (parsedData.data.check) {
+          setIsNewAlarm(true);
+          fetchAlarm();
+        }
+      }
+    };
+
+    eventSource.onerror = () => {
+      eventSource.close();
+      eventSourceRef.current = null;
+      setTimeout(() => {
+        eventSourceRef.current = createEventSource();
+      }, reconnectDelay);
+    };
+
+    return eventSource;
+  };
 
   const clearAllAlarms = () => {
-    setAlarms([]);
+    const deleteAlarm = async () => {
+      try {
+        const response = await clearAlarm();
+        if (response.success) {
+          setAlarms([]);
+        } else {
+          await alert(response.message || '알림 삭제 중 오류가 발생했습니다. 다시 시도해주세요.');
+        }
+      } catch {
+        await alert('알림 삭제 중 오류가 발생했습니다. 다시 시도해주세요.');
+      }
+    };
+
+    deleteAlarm();
   };
 
   const toggleAlarmModal = () => {
     if (!isBarOpen) setIsAlarmOpen(!isAlarmOpen);
+    setIsNewAlarm(false);
   };
 
   const toggleBarModal = () => {
     if (!isAlarmOpen) setIsBarOpen(!isBarOpen);
   };
+
+  useEffect(() => {
+    fetchAlarm();
+
+    eventSourceRef.current = createEventSource();
+
+    return () => {
+      eventSourceRef.current?.close();
+      eventSourceRef.current = null;
+    };
+  }, []);
 
   return (
     <header className="fixed top-[30px] left-0 w-full flex items-center justify-between px-16 z-[50] select-none">
@@ -79,8 +129,12 @@ const Header: React.FC = () => {
       <div className="flex items-center gap-8">
         <div
           onClick={toggleAlarmModal}
-          className="bg-alarm bg-no-repeat bg-contain w-[50px] h-[50px] cursor-pointer"
-        ></div>
+          className="relative bg-alarm bg-no-repeat bg-contain w-[55px] h-[50px] cursor-pointer"
+        >
+          {isNewAlarm && (
+            <span className="absolute top-2 right-0 w-3 h-3 bg-red-500 rounded-full animate-pulse shadow-lg"></span>
+          )}
+        </div>
 
         <div
           onClick={toggleBarModal}
@@ -90,6 +144,8 @@ const Header: React.FC = () => {
 
       <AlarmModal
         alarms={alarms}
+        setIsNewAlarm={setIsNewAlarm}
+        error={error}
         isOpen={isAlarmOpen}
         closeModal={() => setIsAlarmOpen(false)}
         clearAllAlarms={clearAllAlarms}

--- a/apps/frontend/src/components/LoginModal.tsx
+++ b/apps/frontend/src/components/LoginModal.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ModalStep } from '@/constants/ModalConstants';
 import { login } from '@/services/AuthApi';
 import { useUser } from '@/components/UserContext';
+import { AlertContext } from '@/components/AlertContext';
 
 interface LoginProps {
   setModalStep: (step: ModalStep) => void;
@@ -12,38 +13,33 @@ const LoginModal: React.FC<LoginProps> = ({ setModalStep }) => {
   const navigate = useNavigate();
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const { setNickname } = useUser();
+  const { alert } = useContext(AlertContext);
 
   const handleLogin = async () => {
     const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
     if (!email || !emailRegex.test(email)) {
-      setErrorMessage('유효한 이메일을 입력해주세요.');
+      setError('유효한 이메일을 입력해주세요.');
       return;
     }
 
     if (!email || !password) {
-      setErrorMessage('이메일과 비밀번호를 모두 입력해주세요.');
+      setError('이메일과 비밀번호를 모두 입력해주세요.');
       return;
     }
 
     try {
       const response = await login({ email, password });
       if (response.success) {
-        alert(response.message);
         setNickname(response.nickname);
-        setErrorMessage(null);
         navigate('/main');
       } else {
-        setErrorMessage(response.message || '로그인 중 오류가 발생했습니다.');
+        await alert(response.message || '로그인 중 오류가 발생했습니다. 다시 시도해주세요.');
       }
-    } catch (error) {
-      if (error instanceof Error) {
-        setErrorMessage(error.message || '서버와의 연결에 실패했습니다.');
-      } else {
-        setErrorMessage('서버와의 연결에 실패했습니다.');
-      }
+    } catch {
+      await alert('로그인 중 오류가 발생했습니다. 다시 시도해주세요.');
     }
   };
 
@@ -85,7 +81,7 @@ const LoginModal: React.FC<LoginProps> = ({ setModalStep }) => {
         />
       </div>
 
-      {errorMessage && <div className="text-sm text-red-600 mb-4">{errorMessage}</div>}
+      {error && <div className="text-sm text-red-600 mb-4">{error}</div>}
 
       <button
         className="m-2 p-2 bg-brown-dark text-light-gray rounded-lg min-w-[300px] min-h-[40px]"

--- a/apps/frontend/src/components/OwnCrop.tsx
+++ b/apps/frontend/src/components/OwnCrop.tsx
@@ -47,7 +47,7 @@ const OwnCrop: React.FC = () => {
             <th>보유가액</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody className="md:h-24 lg:h-26 xl:h-28 ">
           {currentCrops.map(({ crop, ownedAmount, ownedValue }, idx) => (
             <tr key={idx}>
               <td>{crop}</td>

--- a/apps/frontend/src/components/Profile.tsx
+++ b/apps/frontend/src/components/Profile.tsx
@@ -1,8 +1,9 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useContext } from 'react';
 import EditIcon from '@/components/EditIcon';
 import SaveIcon from './SaveIcon';
 import { updateIntroduce } from '@/services/AuthApi';
 import { getMyRank } from '@/services/RankApi';
+import { AlertContext } from '@/components/AlertContext';
 
 interface ProfileProps {
   id: string;
@@ -16,6 +17,7 @@ const Profile: React.FC<ProfileProps> = ({ id, modalOpen }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [myRank, setMyRank] = useState<number>(0);
   const [error, setError] = useState<string | null>('데이터 로딩 중 오류가 발생했습니다.');
+  const { alert } = useContext(AlertContext);
 
   useEffect(() => {
     const fetchMyRank = async () => {
@@ -23,16 +25,11 @@ const Profile: React.FC<ProfileProps> = ({ id, modalOpen }) => {
         const response = await getMyRank();
         if (response.success) {
           setMyRank(response.rank || 0);
-          setError(null);
         } else {
           setError(response.message || '데이터 로딩 중 오류가 발생했습니다.');
         }
-      } catch (error) {
-        if (error instanceof Error) {
-          setError(error.message || '서버와의 연결에 실패했습니다.');
-        } else {
-          setError('서버와의 연결에 실패했습니다.');
-        }
+      } catch {
+        setError('서버와의 연결에 실패했습니다.');
       }
     };
 
@@ -58,9 +55,11 @@ const Profile: React.FC<ProfileProps> = ({ id, modalOpen }) => {
       const response = await updateIntroduce({ introduce: newIntroduce });
       if (response.success) {
         setIntroduce(newIntroduce);
+      } else {
+        await alert(response.message || '소개글 변경에 실패했습니다. 다시 시도해주세요.');
       }
     } catch {
-      alert('소개글 변경에 실패했습니다. 다시 시도해주세요.');
+      await alert('소개글 변경에 실패했습니다. 다시 시도해주세요.');
     }
   };
 

--- a/apps/frontend/src/components/SignUpModal.tsx
+++ b/apps/frontend/src/components/SignUpModal.tsx
@@ -1,7 +1,9 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ModalStep } from '@/constants/ModalConstants';
-import { signUp } from '@/services/AuthApi';
+import { signUp, login } from '@/services/AuthApi';
+import { useUser } from './UserContext';
+import { AlertContext } from '@/components/AlertContext';
 
 interface SignUpModalProps {
   step: number;
@@ -14,7 +16,9 @@ const SignUpModal: React.FC<SignUpModalProps> = ({ step, setModalStep }) => {
   const [password, setPassword] = useState<string>('');
   const [pwCheck, setPwCheck] = useState<string>('');
   const [id, setId] = useState<string>('');
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { setNickname } = useUser();
+  const { alert } = useContext(AlertContext);
 
   const emailInputRef = useRef<HTMLInputElement>(null);
   const passwordInputRef = useRef<HTMLInputElement>(null);
@@ -24,42 +28,55 @@ const SignUpModal: React.FC<SignUpModalProps> = ({ step, setModalStep }) => {
   const handleSign1 = () => {
     const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
     if (!email || !emailRegex.test(email)) {
-      setErrorMessage('유효한 이메일을 입력해주세요.');
+      setError('유효한 이메일을 입력해주세요.');
       emailInputRef.current?.focus();
       return;
     }
 
     if (!password || password.length < 8 || password.length > 16) {
-      setErrorMessage('비밀번호는 8자 이상, 16자 이하로 입력해주세요.');
+      setError('비밀번호는 8자 이상, 16자 이하로 입력해주세요.');
       passwordInputRef.current?.focus();
       return;
     }
 
     if (password !== pwCheck) {
-      setErrorMessage('비밀번호가 일치하지 않습니다.');
+      setError('비밀번호가 일치하지 않습니다.');
       pwCheckInputRef.current?.focus();
       return;
     }
 
-    setErrorMessage(null);
+    setError(null);
     setModalStep(ModalStep.SignUpStep2);
   };
 
   const handleSign2 = async () => {
     if (!id || id.length < 2 || id.length > 10) {
-      setErrorMessage('닉네임는 2자 이상, 10자 이하로 입력해주세요.');
+      setError('닉네임는 2자 이상, 10자 이하로 입력해주세요.');
       idInputRef.current?.focus();
       return;
     }
 
-    setErrorMessage(null);
+    setError(null);
 
-    const response = await signUp({ email, password, nickname: id });
+    const signUpResponse = await signUp({ email, password, nickname: id });
 
-    if (response.success) {
-      navigate('/main');
+    if (signUpResponse.success) {
+      await alert('회원가입이 완료되었습니다. 로그인 중입니다...');
+      try {
+        const loginResponse = await login({ email, password });
+        if (loginResponse.success) {
+          setNickname(loginResponse.nickname);
+          navigate('/main');
+        } else {
+          await alert(loginResponse.message || '로그인 중 오류가 발생했습니다. 다시 시도해주세요.');
+          navigate('/');
+        }
+      } catch {
+        await alert('로그인 중 오류가 발생했습니다. 다시 시도해주세요.');
+        navigate('/');
+      }
     } else {
-      setErrorMessage(response.message);
+      setError(signUpResponse.message || '회원가입 중 오류가 발생했습니다. 다시 시도해주세요.');
     }
   };
 
@@ -101,7 +118,7 @@ const SignUpModal: React.FC<SignUpModalProps> = ({ step, setModalStep }) => {
               onChange={e => setPwCheck(e.target.value)}
             />
           </div>
-          {errorMessage && <div className="text-sm text-red-600 mb-4">{errorMessage}</div>}
+          {error && <div className="text-sm text-red-600 mb-4">{error}</div>}
           <button
             className="mt-4 p-2 bg-brown-dark text-light-gray rounded-lg min-w-[300px] min-h-[40px]"
             onClick={handleSign1}
@@ -124,7 +141,7 @@ const SignUpModal: React.FC<SignUpModalProps> = ({ step, setModalStep }) => {
               onChange={e => setId(e.target.value)}
             />
           </div>
-          {errorMessage && <div className="my-2 text-sm text-red-600">{errorMessage}</div>}
+          {error && <div className="my-2 text-sm text-red-600">{error}</div>}
           <button
             className="mt-2 p-2 bg-brown-dark text-light-gray rounded-lg min-w-[300px] min-h-[40px]"
             onClick={handleSign2}

--- a/apps/frontend/src/components/UserContext.tsx
+++ b/apps/frontend/src/components/UserContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
 
 interface UserContextType {
   nickname: string;

--- a/apps/frontend/src/pages/CropMarket.tsx
+++ b/apps/frontend/src/pages/CropMarket.tsx
@@ -48,7 +48,7 @@ const CropMarket: React.FC = () => {
             <Chart timeData={timeData} />
           </div>
         </section>
-        <section className="w-full flex flex-row items-start gap-4 lg:gap-8 xl:gap-10 2xl:gap-24">
+        <section className="w-[95%] flex flex-row justify-between items-start">
           <WoodBoard>
             <h3 className="flex justify-center lg:text-sm xl:text-base font-bold mb-2">
               오늘의 {crop} 가격

--- a/apps/frontend/src/pages/Lottery.tsx
+++ b/apps/frontend/src/pages/Lottery.tsx
@@ -38,12 +38,8 @@ const Lottery: React.FC = () => {
       } else {
         setError(response.message || '오류가 발생했습니다.');
       }
-    } catch (error) {
-      if (error instanceof Error) {
-        setError(error.message || '서버와의 연결에 실패했습니다.');
-      } else {
-        setError('서버와의 연결에 실패했습니다.');
-      }
+    } catch {
+      setError('서버와의 연결에 실패했습니다.');
     }
   };
 

--- a/apps/frontend/src/pages/Ranking.tsx
+++ b/apps/frontend/src/pages/Ranking.tsx
@@ -21,12 +21,8 @@ const Ranking: React.FC = () => {
         } else {
           setError1(response.message || '데이터 로딩 중 오류가 발생했습니다.');
         }
-      } catch (error) {
-        if (error instanceof Error) {
-          setError1(error.message || '서버와의 연결에 실패했습니다.');
-        } else {
-          setError1('서버와의 연결에 실패했습니다.');
-        }
+      } catch {
+        setError1('서버와의 연결에 실패했습니다.');
       }
     };
 
@@ -40,12 +36,8 @@ const Ranking: React.FC = () => {
         } else {
           setError2(response.message || '데이터 로딩 중 오류가 발생했습니다.');
         }
-      } catch (error) {
-        if (error instanceof Error) {
-          setError2(error.message || '서버와의 연결에 실패했습니다.');
-        } else {
-          setError2('서버와의 연결에 실패했습니다.');
-        }
+      } catch {
+        setError2('서버와의 연결에 실패했습니다.');
       }
     };
 

--- a/apps/frontend/src/services/AuthApi.tsx
+++ b/apps/frontend/src/services/AuthApi.tsx
@@ -1,13 +1,13 @@
-import { AxiosError } from 'axios';
 import { Login, SignUp, Introduce, Nickname } from '@/types/Index';
 import { api } from './Api';
+import { handleError } from './HandleError';
 
 export const login = async (data: Login) => {
   try {
     const response = await api.post('auth/login', data);
 
     if (response.data.code === 200) {
-      const { accessToken, refreshToken, nickname } = response.data.data!;
+      const { accessToken, refreshToken, nickname } = response.data.data;
       localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
 
@@ -20,17 +20,7 @@ export const login = async (data: Login) => {
 
     return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
   } catch (error) {
-    if (error instanceof AxiosError) {
-      if (error.response?.data) {
-        const { code, message } = error.response.data;
-
-        if (code === 400 || code === 401) {
-          return { success: false, message: message || '잘못된 요청입니다.' };
-        }
-      }
-    }
-
-    return { success: false, message: '로그인 중 오류가 발생했습니다.' };
+    return handleError(error, '로그인 중 오류가 발생했습니다.');
   }
 };
 
@@ -44,17 +34,7 @@ export const signUp = async (data: SignUp) => {
 
     return { success: false, message: response.data.message };
   } catch (error) {
-    if (error instanceof AxiosError) {
-      if (error.response?.data) {
-        const { code, message } = error.response.data;
-
-        if (code === 400) {
-          return { success: false, message: message || '잘못된 요청입니다.' };
-        }
-      }
-    }
-
-    return { success: false, message: '회원가입 중 오류가 발생했습니다.' };
+    return handleError(error, '회원가입 중 오류가 발생했습니다.');
   }
 };
 
@@ -67,25 +47,12 @@ export const logout = async () => {
       localStorage.removeItem('refreshToken');
       localStorage.removeItem('nickname');
 
-      return {
-        success: true,
-        message: response.data.message
-      };
+      return { success: true, message: response.data.message };
     }
 
     return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
   } catch (error) {
-    if (error instanceof AxiosError) {
-      if (error.response?.data) {
-        const { code, message } = error.response.data;
-
-        if (code === 401) {
-          return { success: false, message: message || '잘못된 요청입니다.' };
-        }
-      }
-    }
-
-    return { success: false, message: '로그아웃 중 오류가 발생했습니다.' };
+    return handleError(error, '로그아웃 중 오류가 발생했습니다.');
   }
 };
 
@@ -98,17 +65,7 @@ export const updateNickname = async (data: Nickname) => {
     }
     return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
   } catch (error) {
-    if (error instanceof AxiosError) {
-      if (error.response?.data) {
-        const { code, message } = error.response.data;
-
-        if (code === 400) {
-          return { success: false, message: message || '잘못된 요청입니다.' };
-        }
-      }
-    }
-
-    return { success: false, message: '닉네임 변경 중 오류가 발생했습니다.' };
+    return handleError(error, '닉네임 변경 중 오류가 발생했습니다.');
   }
 };
 
@@ -117,15 +74,12 @@ export const updateIntroduce = async (data: Introduce) => {
     const response = await api.patch('auth/introduce', data);
 
     if (response.data.code === 200) {
-      return {
-        success: true,
-        message: response.data.message
-      };
+      return { success: true, message: response.data.message };
     }
 
     return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
-  } catch {
-    return { success: false, message: '소개글 변경 중 오류가 발생했습니다.' };
+  } catch (error) {
+    return handleError(error, '소개글 변경 중 오류가 발생했습니다.');
   }
 };
 

--- a/apps/frontend/src/services/HandleError.tsx
+++ b/apps/frontend/src/services/HandleError.tsx
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+type ErrorResponse = { success: false; message: string };
+
+export const handleError = (error: unknown, defaultMessage: string): ErrorResponse => {
+  if (axios.isAxiosError(error)) {
+    if (error.response?.data) {
+      const { code, message } = error.response.data;
+
+      if (code) {
+        return { success: false, message: message || '잘못된 요청입니다.' };
+      }
+    }
+  }
+
+  return { success: false, message: defaultMessage };
+};

--- a/apps/frontend/src/services/LotteryApi.tsx
+++ b/apps/frontend/src/services/LotteryApi.tsx
@@ -1,5 +1,5 @@
-import { AxiosError } from 'axios';
 import { api } from './Api';
+import { handleError } from './HandleError';
 
 export const getLottoResult = async () => {
   try {
@@ -8,20 +8,15 @@ export const getLottoResult = async () => {
     if (response.data.code === 200) {
       const { remainCash, rank } = response.data.data;
 
-      return { success: true, remainCash, rank };
+      return {
+        success: true,
+        message: response.data.message,
+        remainCash: remainCash,
+        rank: rank
+      };
     }
     return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
   } catch (error) {
-    if (error instanceof AxiosError) {
-      if (error.response?.data) {
-        const { code, message } = error.response.data;
-
-        if (code === 400 || code === 500) {
-          return { success: false, message: message || '잘못된 요청입니다.' };
-        }
-      }
-    }
-
-    return { success: false, message: '데이터 로딩 중 오류가 발생했습니다.' };
+    return handleError(error, '데이터 로딩 중 오류가 발생했습니다.');
   }
 };

--- a/apps/frontend/src/services/MailApi.tsx
+++ b/apps/frontend/src/services/MailApi.tsx
@@ -1,0 +1,34 @@
+import { handleError } from './HandleError';
+import { api } from './Api';
+
+export const getAlarm = async () => {
+  try {
+    const response = await api.get('mail');
+
+    if (response.data.code === 200) {
+      const alarm = response.data.data;
+
+      return {
+        success: true,
+        message: response.data.message,
+        alarm: alarm
+      };
+    }
+    return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
+  } catch (error) {
+    return handleError(error, '데이터 로딩 중 오류가 발생했습니다.');
+  }
+};
+
+export const clearAlarm = async () => {
+  try {
+    const response = await api.delete('mail');
+
+    if (response.data.code === 200) {
+      return { success: true, message: response.data.message };
+    }
+    return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
+  } catch (error) {
+    return handleError(error, '데이터 로딩 중 오류가 발생했습니다.');
+  }
+};

--- a/apps/frontend/src/services/RankApi.tsx
+++ b/apps/frontend/src/services/RankApi.tsx
@@ -1,3 +1,4 @@
+import { handleError } from './HandleError';
 import { api } from './Api';
 
 export const getTop5 = async () => {
@@ -5,15 +6,18 @@ export const getTop5 = async () => {
     const response = await api.get('rank/top5');
 
     if (response.data.code === 200) {
-      const top5 = response.data.data;
-      return { success: true, message: response.data.message, top5 };
+      const { top5 } = response.data.data;
+
+      return {
+        success: true,
+        message: response.data.message,
+        top5: top5
+      };
     }
+
     return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
   } catch (error) {
-    if (error instanceof Error) {
-      return { success: false, message: '데이터 로딩 중 오류가 발생했습니다.' };
-    }
-    return { success: false, message: '데이터 로딩 중 오류가 발생했습니다.' };
+    return handleError(error, '데이터 로딩 중 오류가 발생했습니다.');
   }
 };
 
@@ -24,8 +28,14 @@ export const getMyRank = async () => {
     if (response.data.code === 200) {
       const { rank, percentage } = response.data.data;
 
-      return { success: true, message: response.data.message, rank, percentage };
+      return {
+        success: true,
+        message: response.data.message,
+        rank: rank,
+        percentage: percentage
+      };
     }
+
     return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
   } catch (error) {
     if (error instanceof Error) {

--- a/apps/frontend/src/types/Alarm.ts
+++ b/apps/frontend/src/types/Alarm.ts
@@ -1,6 +1,6 @@
 export interface Alarm {
   mailId: number;
   content: string;
-  createAt: string;
+  createdAt: string;
   readStatus: boolean;
 }

--- a/apps/frontend/src/types/event-source-polyfill.d.ts
+++ b/apps/frontend/src/types/event-source-polyfill.d.ts
@@ -1,0 +1,1 @@
+declare module 'event-source-polyfill';


### PR DESCRIPTION
## 주요 작업

- [x] 알림 기능 추가
- [x] alert 커스텀 컴포넌트 생성 
- [x] 리팩토링 

- alert 이미지
  - alert창 떠있는 동안에는 다른 동작 불가능
  - enter 키로 종료 가능
  - 명시적으로 메세지를 보여줘야할 것 같은 case(회원가입 후 바로 로그인, 버튼이나 폼 제출 후 에러 발생)
<img width="1512" alt="스크린샷 2024-11-26 오후 6 42 58" src="https://github.com/user-attachments/assets/83bb3a53-ebd3-4486-aefa-8b4a01de8c46">

## 트러블 슈팅

- SSE 연결시, 인증 토큰을 함께 보내야하는 상황에서 EventSource의 Type에 headers가 존재하지 않았음.
- [event-source-polyfill 라이브러리](https://velog.io/@ongsim123/Devlog-SSE%EB%A1%9C%EC%A7%81-%EA%B5%AC%ED%98%84-%EC%A4%91-EventSource%EC%97%90-headers%EB%8B%B4%EA%B8%B0)를 사용하여, XHR Header type을 수동적으로 주입하여 해결
  - `'event-source-polyfill '에 대한 선언 파일을 찾을 수 없습니다.` 에러 발생
    - [type 폴더에 d.ts 파일 생성하기](https://kimchanjung.github.io/programming/2020/07/05/typescipt-import-js-module-error/)로 해결
  - `No activity within 45000 milliseconds. Reconnecting` 에러 발생
    - 서버 - 클라 연결 후, 서버는 주기적으로 이벤트를 보내서 연결 유지가 필요함
    - `event-source-polyfill ` 라이브러리 사용시, default로 45000 milliseconds 마다 연결이 종료되었음을 체크하게 됨.
    - 따라서 위와 같은 에러 발생과 동시에 재연결을 시도하게 됨
    - 서버에서 일정 주기마다 이벤트를 발생하도록 해서 해결
    - or 연결 요청 헤더에서 `heartbeatTimeout` 옵션에 시간을 적어주면, 연결 종료 체크 시간을 늘릴 수 있음. 설마 이 시간동안 이벤트가 하나도 안오가겠어? 이런 느낌
  - 재연결시, 기존 연결되었던 SSE가 죽지 않고 keep-alive 상태로 유지됨.
    - 해결 방안 고민중
