### PR TITLE
[FE/feature] 작물시장 기능 및 UI 수정

### DIFF
--- a/apps/backend/src/websocket/websocket.gateway.ts
+++ b/apps/backend/src/websocket/websocket.gateway.ts
@@ -82,7 +82,14 @@ export class WebsocketGateway implements OnGatewayInit, OnGatewayConnection, OnG
                 WHERE member_id = $1
             `;
         const crops = await this.databaseService.query(query, [memberId]);
-        this.cropDataTransfer(memberId, crops.rows);
+        const data = crops.rows.map(crop => ({
+          cropId: crop.crop_id,
+          availableQuantity: crop.available_quantity,
+          pendingQuantity: crop.pending_quantity,
+          totalQuantity: crop.total_quantity
+        }));
+
+        this.cropDataTransfer(memberId, data);
       });
 
       await subscriber.pSubscribe('__keyspace@0__:orderBook:*', async (_, message) => {

--- a/apps/frontend/src/components/CropMarket/AskingPrice.tsx
+++ b/apps/frontend/src/components/CropMarket/AskingPrice.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 interface AskingPriceProps {
   validCropName: string;
   marketData: {
@@ -8,52 +10,81 @@ interface AskingPriceProps {
 }
 
 const AskingPrice: React.FC<AskingPriceProps> = ({ validCropName, marketData }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop =
+        containerRef.current.scrollHeight / 2 - containerRef.current.clientHeight / 2;
+    }
+  }, [marketData.sellOrders, marketData.buyOrders]);
+
   if (!validCropName) {
     return <div>작물 정보가 없습니다.</div>;
   }
 
+  const maxItems = 4;
+  const emptyOrder = { price: 0, quantity: 0 };
+
+  const sellOrdersToDisplay = [
+    ...new Array(Math.max(0, maxItems - marketData.sellOrders.length)).fill(emptyOrder),
+    ...marketData.sellOrders.sort((a, b) => b.price - a.price).slice(0, maxItems)
+  ];
+
+  const buyOrdersToDisplay = [
+    ...marketData.buyOrders.sort((a, b) => b.price - a.price).slice(0, maxItems),
+    ...new Array(Math.max(0, maxItems - marketData.buyOrders.length)).fill(emptyOrder)
+  ];
+
   return (
-    <div className="w-full h-full md:text-xs lg:text-xs xl:text-sm">
-      <div className="grid grid-cols-[1fr_1fr_1fr] gap-1 font-semibold bg-gray-800 px-1">
+    <div className="w-full h-full md:text-xs lg:text-xs xl:text-sm flex flex-col">
+      <div className="grid grid-cols-[1fr_1fr_1fr] gap-1 font-semibold px-1">
         <div className="text-center">구분</div>
         <div className="text-center">가격</div>
         <div className="text-center">수량</div>
       </div>
-      <div className="md:h-24 lg:h-26 xl:h-28 overflow-y-auto scrollbar-hidden">
-        {marketData.sellOrders
-          .sort((a, b) => b.price - a.price)
-          .map((order, idx) => (
-            <div
-              key={idx}
-              className={`relative grid grid-cols-[1fr_1fr_1fr] gap-1 py-1 px-1 items-center ${
-                order.price === marketData.nowPrice ? 'border border-black' : ''
-              }`}
-            >
-              {order.price === marketData.nowPrice && (
-                <div className="absolute top-1/2 transform -translate-y-1/2 scale-x-[-1] w-0 h-0 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent border-r-[6px] border-r-black"></div>
-              )}
-              <div className="text-center">팔아요</div>
-              <div className="text-center">￦ {order.price}</div>
-              <div className="font-bold text-center text-blue-600">{order.quantity}</div>
+      <div ref={containerRef} className="md:h-24 lg:h-26 xl:h-28 overflow-y-auto scrollbar-hidden">
+        {sellOrdersToDisplay.map((order, idx) => (
+          <div
+            key={idx}
+            className={`relative grid grid-cols-[1fr_1fr_1fr] gap-1 py-1 px-1 items-center ${
+              order.price === marketData.nowPrice && order.price !== 0 ? 'border border-black' : ''
+            }`}
+          >
+            {order.price === marketData.nowPrice && order.price !== 0 && (
+              <div className="absolute top-1/2 transform -translate-y-1/2 scale-x-[-1] w-0 h-0 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent border-r-[6px] border-r-black"></div>
+            )}
+            <div className="text-center">{order.price > 0 ? '팔아요' : '\u00A0'}</div>
+            <div className="text-center">
+              {order.price > 0 ? `￦ ${order.price.toLocaleString()}` : '\u00A0'}
             </div>
-          ))}
-        {marketData.buyOrders
-          .sort((a, b) => b.price - a.price)
-          .map((order, idx) => (
-            <div
-              key={idx}
-              className={`relative grid grid-cols-[1fr_1fr_1fr] gap-1 py-1 px-1 items-center ${
-                order.price === marketData.nowPrice ? 'border border-black' : ''
-              }`}
-            >
-              {order.price === marketData.nowPrice && (
-                <div className="absolute top-1/2 transform -translate-y-1/2 scale-x-[-1] w-0 h-0 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent border-r-[6px] border-r-black"></div>
-              )}
-              <div className="text-center">살게요</div>
-              <div className="text-center">￦ {order.price}</div>
-              <div className="font-bold text-center text-red-500">{order.quantity}</div>
+            <div className="font-bold text-center text-blue-600">
+              {order.quantity > 0 ? order.quantity.toLocaleString() : '\u00A0'}
             </div>
-          ))}
+          </div>
+        ))}
+        {(marketData.sellOrders.length > 0 || marketData.buyOrders.length > 0) && (
+          <hr className="bg-black h-[1px] border-none" />
+        )}
+        {buyOrdersToDisplay.map((order, idx) => (
+          <div
+            key={idx}
+            className={`relative grid grid-cols-[1fr_1fr_1fr] gap-1 py-1 px-1 items-center ${
+              order.price === marketData.nowPrice && order.price !== 0 ? 'border border-black' : ''
+            }`}
+          >
+            {order.price === marketData.nowPrice && order.price !== 0 && (
+              <div className="absolute top-1/2 transform -translate-y-1/2 scale-x-[-1] w-0 h-0 border-t-[6px] border-t-transparent border-b-[6px] border-b-transparent border-r-[6px] border-r-black"></div>
+            )}
+            <div className="text-center">{order.price > 0 ? '살게요' : '\u00A0'}</div>
+            <div className="text-center">
+              {order.price > 0 ? `￦ ${order.price.toLocaleString()}` : '\u00A0'}
+            </div>
+            <div className="font-bold text-center text-red-500">
+              {order.quantity > 0 ? order.quantity.toLocaleString() : '\u00A0'}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/apps/frontend/src/components/CropMarket/OwnCrop.tsx
+++ b/apps/frontend/src/components/CropMarket/OwnCrop.tsx
@@ -31,8 +31,8 @@ const OwnCrop: React.FC<OwnCropProps> = ({ ownCrop, cropNameList, nowPrice }) =>
               return (
                 <tr key={cropId}>
                   <td>{cropDisplayName}</td>
-                  <td>{totalQuantity}</td>
-                  <td>￦ {price * totalQuantity}</td>
+                  <td>{totalQuantity.toLocaleString()}</td>
+                  <td>￦ {(price * totalQuantity).toLocaleString()}</td>
                 </tr>
               );
             })}

--- a/apps/frontend/src/components/CropMarket/Pending.tsx
+++ b/apps/frontend/src/components/CropMarket/Pending.tsx
@@ -43,7 +43,9 @@ const Pending: React.FC<PendingProps> = ({ cropNameList }) => {
     fetchPending();
   }, []);
 
-  const handleCancel = async (order: MergedPendingData) => {
+  const handleCancel = async (e: React.MouseEvent<HTMLButtonElement>, order: MergedPendingData) => {
+    e.currentTarget.blur();
+
     try {
       const data = {
         cropId: order.cropId,
@@ -89,7 +91,7 @@ const Pending: React.FC<PendingProps> = ({ cropNameList }) => {
         <div>{error}</div>
       ) : (
         <>
-          <div className="grid grid-cols-[1.2fr_2fr_1fr_1fr_auto] gap-1 font-semibold bg-gray-800 py-1 px-1">
+          <div className="grid grid-cols-[1.2fr_2fr_1fr_1fr_auto] gap-1 font-semibold py-1 px-1">
             <div className="text-center">작물명</div>
             <div className="text-center">주문시간</div>
             <div className="text-center">수량</div>
@@ -105,12 +107,14 @@ const Pending: React.FC<PendingProps> = ({ cropNameList }) => {
               >
                 <div className="text-center">{cropList[pending.cropName]}</div>
                 <div className="text-center">{formatDate(pending.time)}</div>
-                <div className="text-center">{pending.quantity}</div>
+                <div className="text-center">{pending.unfilledQuantity.toLocaleString()}</div>
                 <div className="text-center">{pending.price.toLocaleString()}</div>
                 <div className="text-center">
                   <button
-                    className="px-1 bg-green-500 text-white rounded text-[9px]"
-                    onClick={() => handleCancel(pending)}
+                    className={`px-1 rounded text-[9px] ${
+                      pending.orderType === 'buy' ? 'bg-red-500' : 'bg-blue-500'
+                    } text-white`}
+                    onClick={e => handleCancel(e, pending)}
                   >
                     취소
                   </button>

--- a/apps/frontend/src/components/CropMarket/Trade.tsx
+++ b/apps/frontend/src/components/CropMarket/Trade.tsx
@@ -1,6 +1,6 @@
-import { CropData } from '@/types/Crop';
+import { CropData, OwnCropData } from '@/types/Crop';
 import { useUser } from '../public/UserContext';
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { AlertContext } from '@/components/public/AlertContext';
 import {
   postLimitBuyOrder,
@@ -15,118 +15,141 @@ interface TradeProps {
   currentCrop: number;
   cropNameList: CropData[];
   setOrderType: (order: string) => void;
+  ownCrop: OwnCropData[];
 }
 
-const Trade: React.FC<TradeProps> = ({ trade, order, currentCrop, cropNameList, setOrderType }) => {
+const Trade: React.FC<TradeProps> = ({
+  trade,
+  order,
+  currentCrop,
+  cropNameList,
+  setOrderType,
+  ownCrop
+}) => {
   const { alert } = useContext(AlertContext);
   const [price, setPrice] = useState<number>(0);
   const [totalAmount, setTotalAmount] = useState<number>(0);
   const [quantity, setQuantity] = useState<number>(0);
-  const { availableCash } = useUser();
+  const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(true);
+  const { availableCash, fetch } = useUser();
 
-  const onlyNumber = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const inputElement = e.target as HTMLInputElement;
-    inputElement.value = inputElement.value.replace(/[^0-9]/g, '');
-  };
-
-  const handleOrderType = (type: string) => {
-    setOrderType(type);
+  useEffect(() => {
     setQuantity(0);
     setPrice(0);
     setTotalAmount(0);
+  }, [trade, order]);
+
+  useEffect(() => {
+    if (order === '시장가') {
+      if (trade === '매수') {
+        setIsButtonDisabled(totalAmount === 0);
+      } else {
+        setIsButtonDisabled(quantity === 0);
+      }
+    } else {
+      setIsButtonDisabled(price === 0 || quantity === 0);
+    }
+  }, [price, quantity, totalAmount, order, trade]);
+
+  const handleOrderType = (type: string) => {
+    setOrderType(type);
   };
 
   const handleIncrease = () => {
-    setPrice(prevPrice => prevPrice + 1000);
+    setPrice(prevPrice => prevPrice + 100);
   };
 
   const handleDecrease = () => {
-    setPrice(prevPrice => (prevPrice - 1000 >= 0 ? prevPrice - 1000 : 0));
+    setPrice(prevPrice => (prevPrice - 100 >= 0 ? prevPrice - 100 : 0));
   };
 
   const handlePriceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPrice(Number(e.target.value));
+    setPrice(Number(e.target.value.replace(/[^0-9]/g, '')));
   };
 
   const handleQuantityChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setQuantity(Number(e.target.value));
+    setQuantity(Number(e.target.value.replace(/[^0-9]/g, '')));
   };
 
   const handleMaxQuantity = () => {
-    if (order === '지정가') {
+    if (trade === '매수') {
       if (price > 0) {
         setQuantity(Math.floor(availableCash / price));
       }
     } else {
-      // 현재 보유 작물 수
-      // TODO - 웹 소켓 연결 후 추가하기
+      const maxOwnCrop = ownCrop.find(o => o.cropId === currentCrop);
+      setQuantity(maxOwnCrop?.availableQuantity || 0);
     }
   };
 
   const handleTotalAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTotalAmount(Number(e.target.value));
+    setTotalAmount(Number(e.target.value.replace(/[^0-9]/g, '')));
   };
 
   const handleMaxTotalAmount = () => {
-    setTotalAmount(Number(availableCash));
+    setTotalAmount(availableCash);
   };
 
-  const handleOrder = async () => {
-    const crop = cropNameList.find(crop => crop.cropId === currentCrop);
+  const handleOrder = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.currentTarget.blur();
 
+    const crop = cropNameList.find(crop => crop.cropId === currentCrop);
     if (!crop) {
       console.error('Crop not found');
       return;
     }
 
-    const cropId: number = crop?.cropId;
-    const tradingType: string = trade === '매수' ? 'buy' : 'sell';
-    const orderType: string = order === '지정가' ? 'limit' : 'market';
+    const cropId: number = crop.cropId;
+    const tradingType = trade === '매수' ? 'buy' : 'sell';
+    const orderType = order === '지정가' ? 'limit' : 'market';
 
-    let orderData;
-    let fetchMethod;
+    const isMarketOrder = orderType === 'market';
+    const isBuyOrder = tradingType === 'buy';
 
-    if (orderType === 'market') {
-      if (tradingType === 'buy') {
-        orderData = {
-          cropId,
-          orderType: tradingType,
-          tradingType: 'market',
-          totalAmount
-        };
-        fetchMethod = postMarketBuyOrder;
-      } else {
-        orderData = {
-          cropId,
-          orderType: tradingType,
-          tradingType: 'market',
-          quantity
-        };
-        fetchMethod = postMarketSellOrder;
+    if (isMarketOrder) {
+      if (isBuyOrder && totalAmount === 0) {
+        await alert('주문 총액을 입력해주세요.');
+        return;
       }
-    } else if (orderType === 'limit') {
-      orderData = {
-        cropId,
-        orderType: tradingType,
-        tradingType: 'limit',
-        quantity,
-        price
-      };
-      fetchMethod = tradingType === 'buy' ? postLimitBuyOrder : postLimitSellOrder;
+      if (!isBuyOrder && quantity === 0) {
+        await alert('주문 수량을 입력해주세요.');
+        return;
+      }
+    } else {
+      if (quantity === 0 || price === 0) {
+        await alert('가격과 주문 수량을 모두 입력해주세요.');
+        return;
+      }
     }
 
-    if (!orderData || !fetchMethod) {
-      console.error('Order data or fetch method is undefined');
-      return;
-    }
+    const orderData = {
+      cropId,
+      orderType: tradingType,
+      tradingType: orderType,
+      ...(isMarketOrder ? (isBuyOrder ? { totalAmount } : { quantity }) : { quantity, price })
+    };
+
+    const fetchMethod = isMarketOrder
+      ? isBuyOrder
+        ? postMarketBuyOrder
+        : postMarketSellOrder
+      : isBuyOrder
+        ? postLimitBuyOrder
+        : postLimitSellOrder;
 
     try {
       const response = await fetchMethod(orderData);
       await alert(response.message);
+      fetch();
     } catch (error) {
       console.error(error);
     }
   };
+
+  const displayValue =
+    trade === '매수'
+      ? availableCash.toLocaleString()
+      : ownCrop.find(o => o.cropId === currentCrop)?.availableQuantity;
 
   return (
     <>
@@ -137,9 +160,7 @@ const Trade: React.FC<TradeProps> = ({ trade, order, currentCrop, cropNameList, 
             <button
               key={type}
               onClick={() => handleOrderType(type)}
-              className={`px-2 py-1 rounded-md text-xs ${
-                order === type ? 'bg-light-pink' : 'bg-gray-100'
-              }`}
+              className={`px-2 py-1 rounded-md text-xs ${order === type && 'bg-light-pink'}`}
             >
               {type}
             </button>
@@ -155,23 +176,14 @@ const Trade: React.FC<TradeProps> = ({ trade, order, currentCrop, cropNameList, 
               <input
                 type="text"
                 value={price}
-                onKeyUp={e => {
-                  onlyNumber(e);
-                }}
                 onChange={handlePriceChange}
                 className="w-24 text-center border rounded-md text-sm px-2 py-1"
               />
 
-              <button
-                className="px-2 py-1 text-center bg-gray-200 rounded-md text-xs"
-                onClick={handleDecrease}
-              >
+              <button className="px-2 py-1 text-center rounded-md text-xs" onClick={handleDecrease}>
                 -
               </button>
-              <button
-                className="px-2 py-1 text-center bg-gray-200 rounded-md text-xs"
-                onClick={handleIncrease}
-              >
+              <button className="px-2 py-1 text-center rounded-md text-xs" onClick={handleIncrease}>
                 +
               </button>
             </div>
@@ -182,15 +194,12 @@ const Trade: React.FC<TradeProps> = ({ trade, order, currentCrop, cropNameList, 
               <input
                 type="text"
                 value={quantity}
-                onKeyUp={e => {
-                  onlyNumber(e);
-                }}
                 onChange={handleQuantityChange}
                 placeholder="0"
-                className="w-24 px-1 py-1 border border-gray rounded text-xs text-center"
+                className="w-24 px-1 py-1 border rounded text-xs text-center"
               />
               <button
-                className="px-2 py-1 bg-gray-200 rounded-md font-semibold text-xs"
+                className="px-2 py-1 rounded-md font-semibold text-xs"
                 onClick={handleMaxQuantity}
               >
                 최대
@@ -199,13 +208,12 @@ const Trade: React.FC<TradeProps> = ({ trade, order, currentCrop, cropNameList, 
           </div>
           <div className="flex items-center justify-between mt-4">
             <span className="font-semibold text-sm">주문 가능</span>
-            <span className="font-semibold text-sm">{availableCash.toLocaleString()} 원</span>
+            <span className="font-semibold text-sm">{displayValue}</span>
           </div>
           <button
-            className={`w-full py-2 mt-10 text-white rounded-md font-semibold text-sm ${
-              trade === '매수' ? 'bg-red-500' : 'bg-blue-500'
-            }`}
+            className={`w-full py-2 mt-10 rounded-md font-semibold text-sm ${isButtonDisabled ? 'opacity-85 cursor-not-allowed' : ''} ${trade === '매수' ? 'bg-red-500 text-white' : 'bg-blue-500 text-white'}`}
             onClick={handleOrder}
+            disabled={isButtonDisabled}
           >
             {trade}
           </button>
@@ -222,15 +230,12 @@ const Trade: React.FC<TradeProps> = ({ trade, order, currentCrop, cropNameList, 
               <input
                 type="text"
                 value={trade === '매수' ? totalAmount : quantity}
-                onKeyUp={e => {
-                  onlyNumber(e);
-                }}
                 onChange={trade === '매수' ? handleTotalAmountChange : handleQuantityChange}
                 placeholder="0"
-                className="w-24 px-1 py-1 border border-gray rounded text-xs text-center"
+                className="w-24 px-1 py-1 border rounded text-xs text-center"
               />
               <button
-                className="px-2 py-1 bg-gray-200 rounded-md font-semibold text-xs"
+                className="px-2 py-1 rounded-md font-semibold text-xs"
                 onClick={trade === '매수' ? handleMaxTotalAmount : handleMaxQuantity}
               >
                 최대
@@ -239,13 +244,12 @@ const Trade: React.FC<TradeProps> = ({ trade, order, currentCrop, cropNameList, 
           </div>
           <div className="flex items-center justify-between mt-8">
             <span className="font-semibold text-sm">주문 가능</span>
-            <span className="font-semibold text-sm">{availableCash.toLocaleString()} 원</span>
+            <span className="font-semibold text-sm">{displayValue}</span>
           </div>
           <button
-            className={`w-full py-2 mt-12 text-white rounded-md font-semibold text-sm ${
-              trade === '매수' ? 'bg-red-500' : 'bg-blue-600'
-            }`}
+            className={`w-full py-2 mt-10 rounded-md font-semibold text-sm ${isButtonDisabled ? 'opacity-85 cursor-not-allowed' : ''} ${trade === '매수' ? 'bg-red-500 text-white' : 'bg-blue-500 text-white'}`}
             onClick={handleOrder}
+            disabled={isButtonDisabled}
           >
             {trade}
           </button>

--- a/apps/frontend/src/components/CropMarket/TradeSection.tsx
+++ b/apps/frontend/src/components/CropMarket/TradeSection.tsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
 import Trade from '@/components/CropMarket/Trade';
 import Pending from '@/components/CropMarket/Pending';
-import { CropData } from '@/types/Crop';
+import { CropData, OwnCropData } from '@/types/Crop';
 
 interface TradeProps {
   currentCrop: number;
   cropNameList: CropData[];
+  ownCrop: OwnCropData[];
 }
 
-const TradeSection: React.FC<TradeProps> = ({ currentCrop, cropNameList }) => {
+const TradeSection: React.FC<TradeProps> = ({ currentCrop, cropNameList, ownCrop }) => {
   const [tradeType, setTradeType] = useState<string>('매수');
   const [orderType, setOrderType] = useState<string>('지정가');
 
@@ -25,7 +26,7 @@ const TradeSection: React.FC<TradeProps> = ({ currentCrop, cropNameList }) => {
             <button
               key={type}
               onClick={() => changeTrade(type)}
-              className={`flex-1 p-2 rounded-lg border border-gray font-bold text-sm ${
+              className={`flex-1 p-2 rounded-lg border font-bold text-sm ${
                 tradeType === type
                   ? type === '매수'
                     ? 'text-white bg-red-500'
@@ -46,6 +47,7 @@ const TradeSection: React.FC<TradeProps> = ({ currentCrop, cropNameList }) => {
             setOrderType={setOrderType}
             currentCrop={currentCrop}
             cropNameList={cropNameList}
+            ownCrop={ownCrop}
           />
         ) : (
           <Pending cropNameList={cropNameList} />

--- a/apps/frontend/src/components/Intro/LoginModal.tsx
+++ b/apps/frontend/src/components/Intro/LoginModal.tsx
@@ -1,8 +1,7 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ModalStep } from '@/constants/ModalConstants';
 import { login } from '@/services/AuthApi';
-import { useUser } from '@/components/public/UserContext';
 import { AlertContext } from '@/components/public/AlertContext';
 
 interface LoginProps {
@@ -14,7 +13,6 @@ const LoginModal: React.FC<LoginProps> = ({ setModalStep }) => {
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
-  const { setNickname } = useUser();
   const { alert } = useContext(AlertContext);
 
   const handleLogin = async () => {
@@ -33,7 +31,6 @@ const LoginModal: React.FC<LoginProps> = ({ setModalStep }) => {
     try {
       const response = await login({ email, password });
       if (response.success) {
-        setNickname(response.nickname);
         navigate('/main');
       } else {
         await alert(response.message || '로그인 중 오류가 발생했습니다. 다시 시도해주세요.');
@@ -50,6 +47,20 @@ const LoginModal: React.FC<LoginProps> = ({ setModalStep }) => {
   const handleKakao = async () => {
     window.location.href = `${import.meta.env.VITE_BASE_URL}/api/auth/kakao`;
   };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        handleLogin();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleLogin]);
 
   return (
     <>

--- a/apps/frontend/src/components/Intro/OauthLogin.tsx
+++ b/apps/frontend/src/components/Intro/OauthLogin.tsx
@@ -1,9 +1,6 @@
 import { useEffect } from 'react';
-import { useUser } from '@/components/public/UserContext';
 
 const OauthLogin: React.FC = () => {
-  const { setNickname } = useUser();
-
   useEffect(() => {
     const handleCallback = () => {
       const urlParams = new URLSearchParams(window.location.search);
@@ -14,7 +11,7 @@ const OauthLogin: React.FC = () => {
       if (accessToken && refreshToken && nickname) {
         localStorage.setItem('accessToken', accessToken);
         localStorage.setItem('refreshToken', refreshToken);
-        setNickname(nickname);
+        localStorage.setItem('nickname', nickname);
 
         setTimeout(() => {
           window.location.href = '/main';

--- a/apps/frontend/src/components/Intro/SignUpModal.tsx
+++ b/apps/frontend/src/components/Intro/SignUpModal.tsx
@@ -1,8 +1,7 @@
-import { useState, useRef, useContext } from 'react';
+import { useState, useRef, useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ModalStep } from '@/constants/ModalConstants';
 import { signUp, login } from '@/services/AuthApi';
-import { useUser } from '@/components/public/UserContext';
 import { AlertContext } from '@/components/public/AlertContext';
 
 interface SignUpModalProps {
@@ -17,7 +16,6 @@ const SignUpModal: React.FC<SignUpModalProps> = ({ step, setModalStep }) => {
   const [pwCheck, setPwCheck] = useState<string>('');
   const [id, setId] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
-  const { setNickname } = useUser();
   const { alert } = useContext(AlertContext);
 
   const emailInputRef = useRef<HTMLInputElement>(null);
@@ -65,7 +63,6 @@ const SignUpModal: React.FC<SignUpModalProps> = ({ step, setModalStep }) => {
       try {
         const loginResponse = await login({ email, password });
         if (loginResponse.success) {
-          setNickname(loginResponse.nickname);
           navigate('/main');
         } else {
           await alert(loginResponse.message || '로그인 중 오류가 발생했습니다. 다시 시도해주세요.');
@@ -79,6 +76,21 @@ const SignUpModal: React.FC<SignUpModalProps> = ({ step, setModalStep }) => {
       setError(signUpResponse.message || '회원가입 중 오류가 발생했습니다. 다시 시도해주세요.');
     }
   };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        if(step === 1) handleSign1();
+        else handleSign2();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleSign1, handleSign2]);
 
   return (
     <div className="flex flex-col items-center select-none">

--- a/apps/frontend/src/components/Intro/SignUpModal.tsx
+++ b/apps/frontend/src/components/Intro/SignUpModal.tsx
@@ -80,7 +80,7 @@ const SignUpModal: React.FC<SignUpModalProps> = ({ step, setModalStep }) => {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Enter') {
-        if(step === 1) handleSign1();
+        if (step === 1) handleSign1();
         else handleSign2();
       }
     };

--- a/apps/frontend/src/components/MyPage/Pagination.tsx
+++ b/apps/frontend/src/components/MyPage/Pagination.tsx
@@ -9,7 +9,7 @@ const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onPage
     <div className="flex justify-center mt-2">
       <button
         onClick={() => onPageChange(currentPage - 1)}
-        className="px-2 py-0.5 border border-gray rounded-l text-sm disabled:opacity-50 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed disabled:shadow-none shadow-md"
+        className="px-2 py-0.5 border rounded-l text-sm disabled:opacity-50 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed disabled:shadow-none shadow-md"
         disabled={currentPage === 1}
       >
         ❮
@@ -18,14 +18,14 @@ const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onPage
         <button
           key={index + 1}
           onClick={() => onPageChange(index + 1)}
-          className={`px-2 py-0.5 border border-gray mx-0.5 text-sm ${currentPage === index + 1 ? 'bg-light-pink' : ''}`}
+          className={`px-2 py-0.5 border mx-0.5 text-sm ${currentPage === index + 1 ? 'bg-light-pink' : ''}`}
         >
           {index + 1}
         </button>
       ))}
       <button
         onClick={() => onPageChange(currentPage + 1)}
-        className="px-2 py-0.5 border border-gray rounded-r text-sm disabled:opacity-50 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed disabled:shadow-none shadow-md"
+        className="px-2 py-0.5 border rounded-r text-sm disabled:opacity-50 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed disabled:shadow-none shadow-md"
         disabled={currentPage === totalPages}
       >
         ❯

--- a/apps/frontend/src/components/MyPage/TransactionTable.tsx
+++ b/apps/frontend/src/components/MyPage/TransactionTable.tsx
@@ -11,12 +11,12 @@ const TransactionTable: React.FC<TransactionTableProps> = ({ displayedTransactio
     <table className="w-full text-xs border-collapse min-h-[194px]">
       <thead>
         <tr className="bg-light-pink text-center">
-          <th className="p-2 border-b-2 border-gray">시간</th>
-          <th className="p-2 border-b-2 border-gray">작물명</th>
-          <th className="p-2 border-b-2 border-gray">거래유형</th>
-          <th className="p-2 border-b-2 border-gray">수량</th>
-          <th className="p-2 border-b-2 border-gray">거래 가격</th>
-          <th className="p-2 border-b-2 border-gray">거래 총액</th>
+          <th className="p-2 border-b-2">시간</th>
+          <th className="p-2 border-b-2">작물명</th>
+          <th className="p-2 border-b-2">거래유형</th>
+          <th className="p-2 border-b-2">수량</th>
+          <th className="p-2 border-b-2">거래 가격</th>
+          <th className="p-2 border-b-2">거래 총액</th>
         </tr>
       </thead>
       <tbody>

--- a/apps/frontend/src/components/public/UserContext.tsx
+++ b/apps/frontend/src/components/public/UserContext.tsx
@@ -73,6 +73,10 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
   useEffect(() => {
     if (isLoggedIn()) {
       fetch();
+      setNickname(() => {
+        const savedNickname = localStorage.getItem('nickname');
+        return savedNickname || '';
+      });
     }
   }, [fetchCash, fetchCurrentValue, location, nickname]);
 

--- a/apps/frontend/src/pages/CropMarket.tsx
+++ b/apps/frontend/src/pages/CropMarket.tsx
@@ -107,7 +107,7 @@ const CropMarket: React.FC = () => {
 
   return (
     <main className="flex flex-row justify-center items-center min-h-screen select-none pt-16 gap-4">
-      <div className="flex flex-col items-start z-[10] gap-4 w-full lg:w-[60%] max-w-[1300px]">
+      <div className="flex flex-col items-start z-[10] gap-4 w-[60%] max-w-[1300px]">
         <div className="w-full flex flex-col justify-start gap-2">
           <CropSelector
             currentCrop={curCrop}
@@ -116,10 +116,10 @@ const CropMarket: React.FC = () => {
             handleIntervalChange={handleIntervalChange}
             cropNameList={cropNameList}
           />
-          <hr className="w-full bg-black h-[1px]" />
+          <hr className="w-full border-none bg-black h-[1px]" />
         </div>
         <section className="w-full items-center bg-light-gray border-4 border-light-pink rounded-2xl p-4">
-          <div className="h-56 flex justify-center items-center w-full sm:h-64 md:h-36 lg:h-64 xl:h-64 2xl:h-72">
+          <div className="flex justify-center items-center w-full sm:h-36 md:h-36 lg:h-64 xl:h-64 2xl:h-72">
             <Chart timeData={timeData} />
           </div>
         </section>
@@ -139,7 +139,7 @@ const CropMarket: React.FC = () => {
         </section>
       </div>
       <div className="flex flex-col items-center z-[10]">
-        <TradeSection cropNameList={cropNameList} currentCrop={curCrop} />
+        <TradeSection cropNameList={cropNameList} currentCrop={curCrop} ownCrop={ownCrop} />
         <img src="/icon.png" className="w-56 h-56" />
       </div>
     </main>

--- a/apps/frontend/src/pages/Intro.tsx
+++ b/apps/frontend/src/pages/Intro.tsx
@@ -52,8 +52,13 @@ const Intro: React.FC = () => {
       ></button>
 
       {modalStep !== ModalStep.None && (
-        <div className="fixed inset-0 flex items-center justify-center">
-          <div className="bg-bg-color opacity-95 p-8 rounded-lg shadow-lg flex flex-col items-center min-w-[500px]">
+        <div
+          className="fixed inset-0 flex items-center justify-center"
+          onClick={closeModal}
+        >
+          <div className="bg-bg-color opacity-95 p-8 rounded-lg shadow-lg flex flex-col items-center min-w-[500px]"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex items-center w-full">
               <BackIcon
                 onClick={() =>

--- a/apps/frontend/src/pages/Intro.tsx
+++ b/apps/frontend/src/pages/Intro.tsx
@@ -52,12 +52,10 @@ const Intro: React.FC = () => {
       ></button>
 
       {modalStep !== ModalStep.None && (
-        <div
-          className="fixed inset-0 flex items-center justify-center"
-          onClick={closeModal}
-        >
-          <div className="bg-bg-color opacity-95 p-8 rounded-lg shadow-lg flex flex-col items-center min-w-[500px]"
-            onClick={(e) => e.stopPropagation()}
+        <div className="fixed inset-0 flex items-center justify-center" onClick={closeModal}>
+          <div
+            className="bg-bg-color opacity-95 p-8 rounded-lg shadow-lg flex flex-col items-center min-w-[500px]"
+            onClick={e => e.stopPropagation()}
           >
             <div className="flex items-center w-full">
               <BackIcon

--- a/apps/frontend/src/services/Api.tsx
+++ b/apps/frontend/src/services/Api.tsx
@@ -46,8 +46,10 @@ api.interceptors.response.use(
     pendingRequests.delete(requestKey);
 
     if (error.response && error.response.status === 401) {
+      console.log(error);
       localStorage.clear();
       alert('액세스 토큰이 만료되었습니다. 로그아웃되었습니다.');
+      window.location.href = '/';
     }
 
     return Promise.reject(error);

--- a/apps/frontend/src/services/AuthApi.tsx
+++ b/apps/frontend/src/services/AuthApi.tsx
@@ -59,21 +59,21 @@ export const logout = async () => {
 
 export const getIntroduce = async () => {
   try {
-      const response = await api.get('auth/introduce');
+    const response = await api.get('auth/introduce');
 
-      if (response.data.code === 200) {
-          const { introduce } = response.data.data;
+    if (response.data.code === 200) {
+      const { introduce } = response.data.data;
 
-          return {
-              success: true,
-              message: response.data.message,
-              introduce
-          };
-      }
+      return {
+        success: true,
+        message: response.data.message,
+        introduce
+      };
+    }
 
-      return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
+    return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
   } catch (error) {
-      return handleError(error, '데이터 로딩 중 오류가 발생했습니다.');
+    return handleError(error, '데이터 로딩 중 오류가 발생했습니다.');
   }
 };
 

--- a/apps/frontend/src/services/AuthApi.tsx
+++ b/apps/frontend/src/services/AuthApi.tsx
@@ -10,6 +10,7 @@ export const login = async (data: Login) => {
       const { accessToken, refreshToken, nickname } = response.data.data;
       localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
+      localStorage.setItem('nickname', nickname);
 
       return {
         success: true,
@@ -58,21 +59,21 @@ export const logout = async () => {
 
 export const getIntroduce = async () => {
   try {
-    const response = await api.get('auth/introduce');
+      const response = await api.get('auth/introduce');
 
-    if (response.data.code === 200) {
-      const { introduce } = response.data.data;
+      if (response.data.code === 200) {
+          const { introduce } = response.data.data;
 
-      return {
-        success: true,
-        message: response.data.message,
-        introduce
-      };
-    }
+          return {
+              success: true,
+              message: response.data.message,
+              introduce
+          };
+      }
 
-    return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
+      return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
   } catch (error) {
-    return handleError(error, '데이터 로딩 중 오류가 발생했습니다.');
+      return handleError(error, '데이터 로딩 중 오류가 발생했습니다.');
   }
 };
 

--- a/apps/frontend/src/services/OrderApi.tsx
+++ b/apps/frontend/src/services/OrderApi.tsx
@@ -72,7 +72,7 @@ export const postMarketBuyOrder = async (data: Order) => {
 
     if (response.data.code === 201) {
       return { success: true, message: response.data.message };
-    } else if(response.data.code === 400) {
+    } else if (response.data.code === 400) {
       return { success: true, message: response.data.message };
     }
 
@@ -88,7 +88,7 @@ export const postMarketSellOrder = async (data: Order) => {
 
     if (response.data.code === 201) {
       return { success: true, message: response.data.message };
-    } else if(response.data.code === 400) {
+    } else if (response.data.code === 400) {
       return { success: true, message: response.data.message };
     }
 

--- a/apps/frontend/src/services/OrderApi.tsx
+++ b/apps/frontend/src/services/OrderApi.tsx
@@ -6,7 +6,7 @@ export const getOrderHistory = async () => {
   try {
     const response = await api.get('order');
 
-    if (response.data.code === 201) {
+    if (response.data.code === 200) {
       const history: HistoryData[] = response.data.data;
 
       return {
@@ -72,6 +72,8 @@ export const postMarketBuyOrder = async (data: Order) => {
 
     if (response.data.code === 201) {
       return { success: true, message: response.data.message };
+    } else if(response.data.code === 400) {
+      return { success: true, message: response.data.message };
     }
 
     return { success: false, message: '알 수 없는 오류가 발생했습니다.' };
@@ -84,7 +86,9 @@ export const postMarketSellOrder = async (data: Order) => {
   try {
     const response = await api.post('order/sell/market', data);
 
-    if (response.data.code === 200) {
+    if (response.data.code === 201) {
+      return { success: true, message: response.data.message };
+    } else if(response.data.code === 400) {
       return { success: true, message: response.data.message };
     }
 

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -25,7 +25,6 @@ export default {
 
         // 회색 계열
         'blue-gray': '#64748B',
-        gray: '#C9C9C9',
 
         // 기타 색상
         black: '#000000',

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -8,12 +8,7 @@ export default defineConfig({
   server: {
     host: true,
     port: 3000,
-    cors: true,
-    hmr: {
-      protocol: 'wss',
-      host: 'yeokjeonnongbu.shop',
-      port: 3000
-    }
+    cors: true
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## 주요 작업

- [x] 대기창 quantity → unfilledQuantity로 수정
- [x] 매도에 주문가능을 돈에서 작물 수량으로 수정
- [x] 매수/매도/대기취소시, alert 창에 엔터 클릭하면 alert가 꺼지는게 아니라 주문이 더 됨
- [x] 현재 기본 오더북 스크롤이 맨 위에 위치해 있는데, “팔아요“, “사요“가 사이로 기본 위치 - 4개씩 배치해서 조정 완료
- [x] 매수매도 input 태그 값 number 처리
- [x] 매수창 주문 가능 금액 → 버튼 누를 때마다 availableCash 다시 fetch 해오도록 기능 추가
- [x] 매수/매도 값 0으로 입력된거 있을 때에는 button disable 상태로 표시하기
- [x] 대기창에 매수/매도 상태 보이도록 하는 방법 - 취소 버튼 색으로 구분
- [x] 토큰 만료시 '/'로 이동되도록 수정 

## 트러블 슈팅

- 